### PR TITLE
fix(login): remove model-data endpoint from SSO interceptor

### DIFF
--- a/base/src/main/java/com/tinyengine/it/login/config/LoginConfig.java
+++ b/base/src/main/java/com/tinyengine/it/login/config/LoginConfig.java
@@ -44,9 +44,7 @@ public class LoginConfig implements WebMvcConfigurer {
                 "/app-center/api/ai/chat",
                 "/app-center/api/chat/completions",
                 // 图片文件资源下载
-                "/material-center/api/resource/download/*",
-                //模型驱动
-                "/platform-center/api/model-data/**"
+                "/material-center/api/resource/download/*"
             );
     }
 }


### PR DESCRIPTION
## Summary
临时移除model-data API鉴权例外，规避风险。
- Remove `/platform-center/api/model-data/**` from the SSO interceptor whitelist to enforce authentication on model-data endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Authentication interception updated so additional platform API endpoints are now validated through the SSO authentication flow, ensuring those requests are processed by the central SSO check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->