### PR TITLE
fix:update block

### DIFF
--- a/base/src/main/java/com/tinyengine/it/common/exception/ExceptionEnum.java
+++ b/base/src/main/java/com/tinyengine/it/common/exception/ExceptionEnum.java
@@ -352,7 +352,12 @@ public enum ExceptionEnum implements IBaseError {
     /**
      * Cm 345 exception enum.
      */
-    CM345("CM345", "用户名不存在,请重新输入"),;
+    CM345("CM345", "用户名不存在,请重新输入"),
+    /**
+     * Cm 346 exception enum.
+     */
+    CM346("CM346", "当前区块已被其他用户锁定");
+    ;
     /**
      * 错误码
      */

--- a/base/src/main/java/com/tinyengine/it/service/material/impl/BlockServiceImpl.java
+++ b/base/src/main/java/com/tinyengine/it/service/material/impl/BlockServiceImpl.java
@@ -173,7 +173,7 @@ public class BlockServiceImpl extends ServiceImpl<BlockMapper, Block> implements
             return Result.failed(ExceptionEnum.CM001);
         }
         if (!Objects.equals(blockResult.getOccupierBy(), loginUserContext.getLoginUserId())) {
-            return Result.failed(ExceptionEnum.CM007);
+            return Result.failed(ExceptionEnum.CM346);
         }
         // 把前端传参赋值给实体
         Block blocks = new Block();


### PR DESCRIPTION
修复更新被锁定区块的提示错误码和错误信息


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the response shown when trying to edit a block already locked by someone else.
  * Added a clearer error message for this case so users now see a more accurate reason the action is blocked.
  * Corrected an enum entry so additional status messages can be handled properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->