### PR TITLE
fix: return existing resource on duplicate upload

### DIFF
--- a/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
+++ b/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
@@ -203,7 +203,6 @@ public class ResourceServiceImpl extends ServiceImpl<ResourceMapper, Resource> i
         queryWrapper.eq("tenant_id", loginUserContext.getTenantId());
         // 接入租户系统需添加租户id查询
         Resource resourceResult = this.baseMapper.selectOne(queryWrapper);
-        log.info("resourceResult: " + resourceResult);
         if (resourceResult != null) {
             return resourceResult;
         }

--- a/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
+++ b/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
@@ -200,7 +200,13 @@ public class ResourceServiceImpl extends ServiceImpl<ResourceMapper, Resource> i
             resource.setThumbnailUrl(thumbnailUrl);
             resource.setThumbnailData(ImageThumbnailGenerator.createThumbnail(resource.getResourceData(), 200, 200));
         }
-
+        QueryWrapper<Resource> queryWrapper = new QueryWrapper<>();
+        queryWrapper.eq("hash", resource.getHash());
+        // 接入租户系统需添加租户id查询
+        Resource resourceResult = this.baseMapper.selectOne(queryWrapper);
+        if (resourceResult != null) {
+            return resourceResult;
+        }
         int createResult = this.baseMapper.createResource(resource);
         if (createResult != 1) {
             throw new ServiceException(ExceptionEnum.CM002.getResultCode(), ExceptionEnum.CM002.getResultMsg());

--- a/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
+++ b/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
@@ -200,13 +200,7 @@ public class ResourceServiceImpl extends ServiceImpl<ResourceMapper, Resource> i
             resource.setThumbnailUrl(thumbnailUrl);
             resource.setThumbnailData(ImageThumbnailGenerator.createThumbnail(resource.getResourceData(), 200, 200));
         }
-        QueryWrapper<Resource> queryWrapper = new QueryWrapper<>();
-        queryWrapper.eq("hash", resource.getHash());
-        // 接入租户系统需添加租户id查询
-        Resource resourceResult = this.baseMapper.selectOne(queryWrapper);
-        if (resourceResult != null) {
-            throw new ServiceException(ExceptionEnum.CM003.getResultCode(), ExceptionEnum.CM003.getResultMsg());
-        }
+
         int createResult = this.baseMapper.createResource(resource);
         if (createResult != 1) {
             throw new ServiceException(ExceptionEnum.CM002.getResultCode(), ExceptionEnum.CM002.getResultMsg());

--- a/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
+++ b/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
@@ -198,6 +198,8 @@ public class ResourceServiceImpl extends ServiceImpl<ResourceMapper, Resource> i
 
         QueryWrapper<Resource> queryWrapper = new QueryWrapper<>();
         queryWrapper.eq("hash", resource.getHash());
+        queryWrapper.eq("app_id", resource.getAppId());
+        queryWrapper.eq("tenant_id", loginUserContext.getTenantId());
         // 接入租户系统需添加租户id查询
         Resource resourceResult = this.baseMapper.selectOne(queryWrapper);
         if (resourceResult != null) {

--- a/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
+++ b/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
@@ -195,17 +195,18 @@ public class ResourceServiceImpl extends ServiceImpl<ResourceMapper, Resource> i
         String resourceUrl = tinyEngineUrl + "/" + imageEncodedName;
         String thumbnailUrl = tinyEngineUrl + "/" + thumbnailEncodedName;
 
-        if (!StringUtils.isEmpty(resourceData)) {
-            resource.setResourceUrl(resourceUrl);
-            resource.setThumbnailUrl(thumbnailUrl);
-            resource.setThumbnailData(ImageThumbnailGenerator.createThumbnail(resource.getResourceData(), 200, 200));
-        }
+
         QueryWrapper<Resource> queryWrapper = new QueryWrapper<>();
         queryWrapper.eq("hash", resource.getHash());
         // 接入租户系统需添加租户id查询
         Resource resourceResult = this.baseMapper.selectOne(queryWrapper);
         if (resourceResult != null) {
             return resourceResult;
+        }
+        if (!StringUtils.isEmpty(resourceData)) {
+            resource.setResourceUrl(resourceUrl);
+            resource.setThumbnailUrl(thumbnailUrl);
+            resource.setThumbnailData(ImageThumbnailGenerator.createThumbnail(resource.getResourceData(), 200, 200));
         }
         int createResult = this.baseMapper.createResource(resource);
         if (createResult != 1) {

--- a/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
+++ b/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
@@ -26,6 +26,7 @@ import com.tinyengine.it.mapper.ResourceMapper;
 import com.tinyengine.it.model.entity.Resource;
 import com.tinyengine.it.model.entity.ResourceGroupResource;
 import com.tinyengine.it.service.material.ResourceService;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -35,7 +36,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-
+@Slf4j
 @Service
 public class ResourceServiceImpl extends ServiceImpl<ResourceMapper, Resource> implements ResourceService {
     /**
@@ -197,15 +198,20 @@ public class ResourceServiceImpl extends ServiceImpl<ResourceMapper, Resource> i
 
 
         QueryWrapper<Resource> queryWrapper = new QueryWrapper<>();
+        log.info("hash: " + resource.getHash());
+        log.info("app id : " + resource.getAppId());
+        log.info("tenantId : " + loginUserContext.getTenantId());
         queryWrapper.eq("hash", resource.getHash());
         queryWrapper.eq("app_id", resource.getAppId());
         queryWrapper.eq("tenant_id", loginUserContext.getTenantId());
         // 接入租户系统需添加租户id查询
         Resource resourceResult = this.baseMapper.selectOne(queryWrapper);
+        log.info("resourceResult: " + resourceResult);
         if (resourceResult != null) {
             return resourceResult;
         }
         if (!StringUtils.isEmpty(resourceData)) {
+            resource.setTenantId(loginUserContext.getTenantId());
             resource.setResourceUrl(resourceUrl);
             resource.setThumbnailUrl(thumbnailUrl);
             resource.setThumbnailData(ImageThumbnailGenerator.createThumbnail(resource.getResourceData(), 200, 200));

--- a/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
+++ b/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
@@ -26,7 +26,6 @@ import com.tinyengine.it.mapper.ResourceMapper;
 import com.tinyengine.it.model.entity.Resource;
 import com.tinyengine.it.model.entity.ResourceGroupResource;
 import com.tinyengine.it.service.material.ResourceService;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -36,7 +35,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-@Slf4j
 @Service
 public class ResourceServiceImpl extends ServiceImpl<ResourceMapper, Resource> implements ResourceService {
     /**

--- a/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
+++ b/base/src/main/java/com/tinyengine/it/service/material/impl/ResourceServiceImpl.java
@@ -198,9 +198,6 @@ public class ResourceServiceImpl extends ServiceImpl<ResourceMapper, Resource> i
 
 
         QueryWrapper<Resource> queryWrapper = new QueryWrapper<>();
-        log.info("hash: " + resource.getHash());
-        log.info("app id : " + resource.getAppId());
-        log.info("tenantId : " + loginUserContext.getTenantId());
         queryWrapper.eq("hash", resource.getHash());
         queryWrapper.eq("app_id", resource.getAppId());
         queryWrapper.eq("tenant_id", loginUserContext.getTenantId());


### PR DESCRIPTION
重复上传图片返回已存在的图片url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Uploading a file that already exists now reuses the existing resource instead of returning an error.
  * Duplicate detection now takes app and tenant context into account, reducing false matches across different scopes.
  * Existing resources returned from the duplicate flow keep their current details without overwriting URLs or thumbnail data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->